### PR TITLE
Fix Postgres pool import for Node ESM runtime

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -116,7 +116,16 @@ export default function AdminPage() {
       });
 
       if (!response.ok) {
-        throw new Error('Excel 파일 업로드에 실패했습니다.');
+        let errorMessage = 'Excel 파일 업로드에 실패했습니다.';
+        try {
+          const errorData = await response.json();
+          if (errorData?.message) {
+            errorMessage = errorData.message;
+          }
+        } catch (parseError) {
+          console.error('Failed to parse Excel upload error response:', parseError);
+        }
+        throw new Error(errorMessage);
       }
 
       const result = await response.json();

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,10 +1,13 @@
 import { Pool as NeonPool, neonConfig } from '@neondatabase/serverless';
 import { drizzle as neonDrizzle, type NeonDatabase } from 'drizzle-orm/neon-serverless';
 import { drizzle as nodePgDrizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { Pool as PgPool } from 'pg';
+import pg from 'pg';
 import { setDefaultResultOrder } from 'dns';
 import WebSocket, { ClientOptions } from 'ws';
 import * as schema from '@shared/schema';
+
+const { Pool: NodePgPool } = pg;
+type PgPool = pg.Pool;
 
 if (!process.env.DATABASE_URL) {
   throw new Error(
@@ -25,13 +28,13 @@ const databaseHost = (() => {
 const isLocalHost = databaseHost === 'localhost' || databaseHost === '127.0.0.1';
 
 type Database = NeonDatabase<typeof schema> | NodePgDatabase<typeof schema>;
-type Pool = NeonPool | PgPool;
+type DatabasePool = NeonPool | PgPool;
 
-let pool: Pool;
+let pool: DatabasePool;
 let db: Database;
 
 if (isLocalHost) {
-  const pgPool = new PgPool({ connectionString });
+  const pgPool = new NodePgPool({ connectionString });
   pool = pgPool;
   db = nodePgDrizzle(pgPool, { schema });
 } else {


### PR DESCRIPTION
## Summary
- load the `pg` Pool from the default export so the ESM server can require the driver without a runtime syntax error
- keep the existing Neon fallback while renaming the pooled type to avoid identifier clashes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68df42ae0a2c832ba00d823a63693e97